### PR TITLE
P0-12: Add CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,106 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+  push:
+    branches: [master]
+  workflow_dispatch: {}
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  # Real values are picked up automatically once added under
+  # Settings -> Secrets and variables -> Actions (never commit real values here).
+  # Sensible fallbacks below let lint/type-check/test/build succeed without them,
+  # since none of those tasks touch a real database or third-party API at
+  # build time (DB/Liveblocks clients are lazily initialized on first use).
+  DATABASE_URL: ${{ secrets.DATABASE_URL || 'postgresql://ci:ci@localhost:5432/ci' }}
+  BETTER_AUTH_SECRET: ${{ secrets.BETTER_AUTH_SECRET || 'ci-placeholder-secret-not-for-prod-use' }}
+  BETTER_AUTH_URL: http://localhost:3000
+  NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY: ${{ secrets.NEXT_PUBLIC_LIVEBLOCKS_PUBLIC_KEY }}
+  LIVEBLOCKS_SECRET_KEY: ${{ secrets.LIVEBLOCKS_SECRET_KEY }}
+  UPLOADTHING_TOKEN: ${{ secrets.UPLOADTHING_TOKEN }}
+  GMAIL_USER: ${{ secrets.GMAIL_USER }}
+  GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+
+jobs:
+  ci:
+    name: Lint, type-check, test, build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Restore turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ github.sha }}
+          restore-keys: |
+            turbo-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            turbo-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type-check
+        run: pnpm check-types
+
+      - name: Unit tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+  e2e:
+    name: E2E smoke test (manual)
+    needs: ci
+    # Playwright's global setup seeds a user directly into a real Postgres DB
+    # and drives a real Liveblocks-backed dev server (see apps/web/e2e/global-setup.ts),
+    # so this only runs on-demand once DATABASE_URL/LIVEBLOCKS_SECRET_KEY/etc. are
+    # populated as real repo secrets - it does not block PRs or pushes.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Run E2E smoke test
+        run: pnpm test:e2e
+        env:
+          E2E_USER_EMAIL: ${{ secrets.E2E_USER_EMAIL }}
+          E2E_USER_PASSWORD: ${{ secrets.E2E_USER_PASSWORD }}
+          E2E_BASE_URL: ${{ secrets.E2E_BASE_URL }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ To target a single workspace: `pnpm --filter web run build` (or `--filter @colla
 
 Playwright (`apps/web/playwright.config.ts` + `apps/web/e2e/`) runs one smoke flow: sign in → create a document → edit it → sign out, against a real dev server (`pnpm dev`, auto-started unless `E2E_BASE_URL` is set) and a real Postgres/Liveblocks backend from `apps/web/.env` — there's no mocking at this layer, so it needs valid credentials the same way `pnpm dev` does. `apps/web/e2e/global-setup.ts` seeds one verified test user directly into Postgres (email/password from `E2E_USER_EMAIL`/`E2E_USER_PASSWORD`, defaulting to `e2e@collabnow.test`) using Better Auth's own `hashPassword` — this sidesteps clicking a real verification-email link, it isn't a security bypass in the app itself. The seed is idempotent and persists across runs; nothing currently tears it down.
 
-There is currently **no CI** configured in this repo (tracked as P0-12 in `docs/ROADMAP.md`) — tests only run when invoked locally for now.
+A GitHub Actions workflow (`.github/workflows/ci.yml`, P0-12) runs `pnpm lint` → `pnpm check-types` → `pnpm test` → `pnpm build` on every PR and push to `master`, with pnpm/turbo caching. Vitest unit tests run in CI; the Playwright E2E smoke test does not (it needs a real Postgres/Liveblocks backend) — it's wired as a separate `workflow_dispatch`-only job for once real secrets are added under repo Settings, and branch protection requiring the main job to pass is a follow-up GitHub settings change coordinated with the repo owner (not yet enabled).
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CollabNow
 
+[![CI](https://github.com/hasnaintypes/collab-now/actions/workflows/ci.yml/badge.svg)](https://github.com/hasnaintypes/collab-now/actions/workflows/ci.yml)
+
 A real-time collaborative document editor built for modern teams. Create, edit, and share documents with live presence, inline comments, and granular access control.
 
 This repo is a **Turborepo monorepo** with a feature-based (screaming architecture) app structure.
@@ -127,6 +129,10 @@ Run from the repo root — Turborepo fans these out to the right workspace(s):
 | `pnpm db:studio` | Open Drizzle Studio |
 
 To target a single workspace directly, use pnpm's `--filter`, e.g. `pnpm --filter web run build`.
+
+## CI
+
+Every PR and push to `master` runs `pnpm lint` → `pnpm check-types` → `pnpm test` → `pnpm build` via GitHub Actions (`.github/workflows/ci.yml`). The Playwright E2E smoke test needs a real Postgres/Liveblocks backend, so it's wired as a separate `workflow_dispatch`-only job rather than blocking every PR.
 
 ## License
 


### PR DESCRIPTION
Closes #12.

## What
- Adds .github/workflows/ci.yml: a required job running install -> lint -> check-types -> test -> build on every PR and push to \master\, using \pnpm/action-setup\ + \ctions/setup-node\'s pnpm cache, plus an \ctions/cache\-backed turbo cache (\.turbo/\) for incremental task caching across runs.
- Env vars consumed via \secrets.X || 'dummy-default'\ so the pipeline works today with zero secrets configured, but automatically picks up real values once added under **Settings -> Secrets and variables -> Actions** (per repo research, none of lint/check-types/test/build touch a real DB or third-party API eagerly - the db/liveblocks clients are lazy proxies).
- Adds a second, non-blocking \e2e\ job gated on \workflow_dispatch\ only - the Playwright smoke test needs a real Postgres + Liveblocks backend (see \pps/web/e2e/global-setup.ts\), so it isn't safe/meaningful to run automatically on every PR (esp. fork PRs, which don't get repo secrets) until the repo owner is ready to supply \DATABASE_URL\/\LIVEBLOCKS_SECRET_KEY\/\E2E_USER_EMAIL\/\E2E_USER_PASSWORD\ as real secrets.
- Updates \CLAUDE.md\ and \README.md\ (+ CI badge) to reflect the new pipeline, replacing the stale 'no CI configured' note.

## Not done in this PR (needs repo owner action)
- **Branch protection** on \master\ requiring the \ci\ job to pass before merge - this is a GitHub repo Settings change, not a file change, and the issue explicitly calls for coordinating with the repo owner.
- **Populating real secrets** (\DATABASE_URL\, \BETTER_AUTH_SECRET\, \LIVEBLOCKS_SECRET_KEY\, \UPLOADTHING_TOKEN\, \GMAIL_USER\/\GMAIL_APP_PASSWORD\, \E2E_USER_EMAIL\/\E2E_USER_PASSWORD\, \E2E_BASE_URL\) under Settings -> Secrets and variables -> Actions. None are required for the required \ci\ job to pass, but real values unlock the manual \e2e\ job and harden \ci\ against future code that reads them eagerly.

## Verification
Ran \pnpm lint\, \pnpm check-types\, \pnpm test\, and \pnpm build\ locally (all pass) to confirm the exact commands the workflow runs succeed; traced every env var read in the codebase to confirm none are required eagerly at build/lint/type-check/unit-test time (see PR discussion / commit message for detail).